### PR TITLE
Small, random menu fixes

### DIFF
--- a/code/multicart/multicart.asm
+++ b/code/multicart/multicart.asm
@@ -231,59 +231,22 @@ rpcwaitloop
                     lda      $1
                     cmpa     # ' '
                     bne      rpcwaitloop
-; NOTE: can't quite get this to work, and not sure why. Doing it the stupid way below
-                                                          ; set up header comparison
-;    ldx #$11
-;    ldy #rpcfn+(vextreme_marker-rpcfndat) ; needs to be relative to where it's copied in ram
-;headerloop
-;    lda ,x+
-;    ldb ,y+
-;    cmpa b
-;    bne newrom
-;    cmpx #$19
-;    bne headerloop
-;    jmp main ;start address
-;newrom
-;    ldu #$f000
-;    pshs u
-;    rts
-;vextreme_marker
-;    fcb "VEXTREME",$80            ; for matching against cart header
-; NOTE: This is the stupid way, but it works
-                    lda      $11
-                    cmpa     # 'V'
+                    ; set up header comparison
+                    ldx      #$11
+                    ldu      #rpcfn+(vextreme_marker-rpcfndat) ; needs to be relative to where it's copied in ram
+headerloop
+                    lda      ,x+
+                    cmpa     ,u+
                     bne      newrom
-                    lda      $12
-                    cmpa     # 'E'
-                    bne      newrom
-                    lda      $13
-                    cmpa     # 'X'
-                    bne      newrom
-                    lda      $14
-                    cmpa     # 'T'
-                    bne      newrom
-                    lda      $15
-                    cmpa     # 'R'
-                    bne      newrom
-                    lda      $16
-                    cmpa     # 'E'
-                    bne      newrom
-                    lda      $17
-                    cmpa     # 'M'
-                    bne      newrom
-                    lda      $18
-                    cmpa     # 'E'
-                    bne      newrom
-                    lda      $19
-                    cmpa     #$80
-                    bne      newrom
-                    jmp      main                         ;start address
-
+                    cmpx     #$1A
+                    bne      headerloop
+                    jmp      loop ;start address
 newrom
                     ldu      #$f000
                     pshs     u
                     rts
-
+vextreme_marker
+                    fcb      "VEXTREME",$80   ; for matching against cart header
 rpcfndatend
 ;***************************************************************************
 ; SUBROUTINE SECTION

--- a/code/veccart/main.c
+++ b/code/veccart/main.c
@@ -37,6 +37,8 @@
 #include "xprintf.h"
 #include "fatfs/ff.h"
 
+#define MENU_TEXT_LEN 20
+
 //Memory for the menu ROM and the running cartridge.
 //We keep both in memory so we can quickly exchange them when a reset has been detected.
 const int menuIndex = 0xfff; // fixed location in multicart.bin
@@ -218,7 +220,7 @@ void loadListing(char *fdir) {
 		removeExtension(name, ".vec");
 		removeExtension(name, ".VEC");
 
-		i = is_dir ? 18 : 20;
+		i = is_dir ? (MENU_TEXT_LEN-2) : MENU_TEXT_LEN;
 		if (is_dir) romData[strpos++]='<';
 		while (*name!=0 && i>0) {
 			if (*name<32) {


### PR DESCRIPTION
1) Got the better, smaller rpc header check routine to work
2) Jump to loop instead of main, now that there's the logo
3) Replace magic constants for menu item length w/ define